### PR TITLE
remove illegal characters from tool name for Windows compatibility

### DIFF
--- a/src/tools.mjs
+++ b/src/tools.mjs
@@ -95,6 +95,8 @@ function createTool(tool, opts={}) {
   const pathname = `gitbook/tools/${slug}`;
   const json = { draft: true, tags: [] };
 
+  tool.name = tool.name.replace(/[<>:"/\\|?*\x00-\x1F]/g, '');
+
   if (!opts.overwrite && fs.existsSync(pathname)) {
     debug("Tool already exists");
   } else {


### PR DESCRIPTION
Replaces Windows-prohibited characters in `tool.name` (line 97) with an empty string, preventing directory creation failures on Windows.