### PR TITLE
fix(slugify): remove Windows-prohibited characters and default to 'un…

### DIFF
--- a/src/tools.mjs
+++ b/src/tools.mjs
@@ -86,7 +86,12 @@ function publishTool(name) {
   fs.writeFileSync(tool.jsonFilePath, toolToJson(json));
 }
 function slugify(toolName) {
-  return toolName.replace(/\s/g, '-').replace(',','').toLowerCase();
+  const safe = toolName
+    .replace(/[<>:"/\\|?*\x00-\x1F]/g, '')
+    .replace(/\s+/g, '-')
+    .replace(/,/g, '')
+    .toLowerCase();
+  return safe || 'untitled';
 }
 function createTool(tool, opts={}) {
   const { name, tags } = tool;


### PR DESCRIPTION
…titled'

Sanitize filenames by stripping < > : " / \ | ? * and control codes.  Fallback to 'untitled' if the entire name is removed.