### PR TITLE
harden: sanitize child_process call in gitbook-export.mjs...

### DIFF
--- a/src/gitbook-export.mjs
+++ b/src/gitbook-export.mjs
@@ -20,7 +20,7 @@
 
 import fs from 'fs';
 import path from 'path';
-import { execSync } from 'child_process';
+import { spawnSync } from 'child_process';
 import matter from './frontmatter.mjs';
 import pkg from './data.mjs';
 import client from './ghproject-client.mjs';
@@ -57,8 +57,8 @@ function saveCheckpoint(checkpoint) {
 
 // Bootstrap: use the tool's last-known updated frontmatter date as initial checkpoint
 function getToolUpdatedAt(toolSlug) {
-  const readmePath = path.join('gitbook', 'tools', toolSlug, 'README.md');
-  if (!fs.existsSync(readmePath)) return null;
+  const readmePath = (!toolSlug || /[/\\]|\.\./.test(toolSlug)) ? null : path.join('gitbook', 'tools', toolSlug, 'README.md');
+  if (!readmePath || !fs.existsSync(readmePath)) return null;
   const { data } = matter(fs.readFileSync(readmePath, 'utf-8'));
   return data.updated ? new Date(data.updated).toISOString() : null;
 }
@@ -68,11 +68,12 @@ function getToolUpdatedAt(toolSlug) {
 // created by the GitBook export itself ("Sync: Export ... from GitBook") are
 // excluded — those are GitBook content, not repo-side edits.
 function lastUnsyncedCommit(toolSlug, since) {
-  const result = execSync(
-    `git log --since="${since}" --grep="^Sync: Export" --invert-grep --format="%h %s" -1 -- "gitbook/tools/${toolSlug}/"`,
+  const result = spawnSync(
+    'git',
+    ['log', `--since=${since}`, '--grep=^Sync: Export', '--invert-grep', '--format=%h %s', '-1', '--', `gitbook/tools/${toolSlug}/`],
     { encoding: 'utf-8' }
   );
-  return result.trim() || null;
+  return result.stdout.trim() || null;
 }
 
 async function getMostRecentMergedCR(spaceId) {


### PR DESCRIPTION
## Summary
Harden input handling in `src/gitbook-export.mjs` (flagged by semgrep).

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | javascript.lang.security.detect-child-process.detect-child-process |
| **Severity** | HIGH |
| **Scanner** | semgrep |
| **Rule** | `javascript.lang.security.detect-child-process.detect-child-process` |
| **File** | `src/gitbook-export.mjs:72` |
| **Assessment** | Defensive hardening |

**Description**: Detected calls to child_process from a function argument `since`. This could lead to a command injection if the input is user controllable. Try to avoid calls to child_process, and if it is needed ensure user input is correctly sanitized or sandboxed. 

## Threat Model Context

This is a private Node.js application (not published to npm). Vulnerabilities affect this application's own runtime only.

## Changes
- `src/gitbook-export.mjs`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

---
*This patch removes an exploit primitive — a code pattern that, while not independently exploitable today, could be chained with other weaknesses by automated exploit-development tooling. Proactive removal of such primitives raises the bar against increasingly capable automated attack tools.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
